### PR TITLE
Bug/Fix logic in OutboundMessagePanel to allow sending WhatsApp messages

### DIFF
--- a/.idea/git_toolbox_prj.xml
+++ b/.idea/git_toolbox_prj.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GitToolBoxProjectSettings">
+    <option name="commitMessageIssueKeyValidationOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
+    <option name="commitMessageValidationEnabledOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/plugin-outbound-cbm.iml" filepath="$PROJECT_DIR$/.idea/plugin-outbound-cbm.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/plugin-outbound-cbm.iml
+++ b/.idea/plugin-outbound-cbm.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="681eebad-587e-49cb-97e7-41f34005af01" name="Changes" comment="Fixed logic in OutboundMessagePanel to allow sending WhatsApp messages if either a content template or a message body is provided.&#10;&#10;Updated shouldBlockSend condition to support this new behavior." />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_BRANCH_BY_REPOSITORY">
+      <map>
+        <entry key="$PROJECT_DIR$" value="master" />
+      </map>
+    </option>
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="GitHubPullRequestSearchHistory"><![CDATA[{
+  "lastFilter": {
+    "state": "OPEN",
+    "assignee": "YuraDukhnoAman"
+  }
+}]]></component>
+  <component name="GitToolBoxStore">
+    <option name="recentBranches">
+      <RecentBranches>
+        <option name="branchesForRepo">
+          <list>
+            <RecentBranchesForRepo>
+              <option name="branches">
+                <list>
+                  <RecentBranch>
+                    <option name="branchName" value="bug/disable-sms" />
+                    <option name="lastUsedInstant" value="1748523675" />
+                  </RecentBranch>
+                  <RecentBranch>
+                    <option name="branchName" value="master" />
+                    <option name="lastUsedInstant" value="1748523609" />
+                  </RecentBranch>
+                  <RecentBranch>
+                    <option name="branchName" value="bug/Outbound-CBM-Master-not-working-4095" />
+                    <option name="lastUsedInstant" value="1748522728" />
+                  </RecentBranch>
+                </list>
+              </option>
+              <option name="repositoryRootUrl" value="file://$PROJECT_DIR$" />
+            </RecentBranchesForRepo>
+          </list>
+        </option>
+      </RecentBranches>
+    </option>
+  </component>
+  <component name="GithubPullRequestsUISettings"><![CDATA[{
+  "selectedUrlAndAccountId": {
+    "url": "https://github.com/TwilioByAman/plugin-outbound-cbm.git",
+    "accountId": "4b7cc277-8ec2-4646-9856-94ae66797bf8"
+  },
+  "recentNewPullRequestHead": {
+    "server": {
+      "useHttp": false,
+      "host": "github.com",
+      "port": null,
+      "suffix": null
+    },
+    "owner": "TwilioByAman",
+    "repository": "plugin-outbound-cbm"
+  }
+}]]></component>
+  <component name="ProblemsViewState">
+    <option name="selectedTabId" value="CurrentFile" />
+  </component>
+  <component name="ProjectColorInfo"><![CDATA[{
+  "associatedIndex": 5
+}]]></component>
+  <component name="ProjectId" id="2xliVBqTIKLuTQiA4kYFmTLrwW7" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "git-widget-placeholder": "bug/disable-sms",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "ts.external.directory.path": "/Applications/WebStorm.app/Contents/plugins/javascript-plugin/jsLanguageServicesImpl/external"
+  }
+}]]></component>
+  <component name="RecentsManager">
+    <key name="MoveFile.RECENT_KEYS">
+      <recent name="$PROJECT_DIR$" />
+    </key>
+  </component>
+  <component name="RunManager">
+    <configuration name="start" type="js.build_tools.npm" nameIsGenerated="true">
+      <package-json value="$PROJECT_DIR$/package.json" />
+      <command value="run" />
+      <scripts>
+        <script value="start" />
+      </scripts>
+      <node-interpreter value="project" />
+      <envs />
+      <method v="2" />
+    </configuration>
+  </component>
+  <component name="SharedIndexes">
+    <attachedChunks>
+      <set>
+        <option value="bundled-js-predefined-d6986cc7102b-6a121458b545-JavaScript-WS-251.25410.117" />
+      </set>
+    </attachedChunks>
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="681eebad-587e-49cb-97e7-41f34005af01" name="Changes" comment="" />
+      <created>1748519081871</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1748519081871</updated>
+      <workItem from="1748519082931" duration="10396000" />
+    </task>
+    <task id="LOCAL-00001" summary="remove sms and shouldBlockSend changed">
+      <option name="closed" value="true" />
+      <created>1748522761592</created>
+      <option name="number" value="00001" />
+      <option name="presentableId" value="LOCAL-00001" />
+      <option name="project" value="LOCAL" />
+      <updated>1748522761592</updated>
+    </task>
+    <task id="LOCAL-00002" summary="remove sms and shouldBlockSend changed">
+      <option name="closed" value="true" />
+      <created>1748523468516</created>
+      <option name="number" value="00002" />
+      <option name="presentableId" value="LOCAL-00002" />
+      <option name="project" value="LOCAL" />
+      <updated>1748523468516</updated>
+    </task>
+    <task id="LOCAL-00003" summary="remove sms and shouldBlockSend changed">
+      <option name="closed" value="true" />
+      <created>1748523719622</created>
+      <option name="number" value="00003" />
+      <option name="presentableId" value="LOCAL-00003" />
+      <option name="project" value="LOCAL" />
+      <updated>1748523719622</updated>
+    </task>
+    <task id="LOCAL-00004" summary="Fixed logic in OutboundMessagePanel to allow sending WhatsApp messages if either a content template or a message body is provided.&#10;&#10;Updated shouldBlockSend condition to support this new behavior.">
+      <option name="closed" value="true" />
+      <created>1748752902990</created>
+      <option name="number" value="00004" />
+      <option name="presentableId" value="LOCAL-00004" />
+      <option name="project" value="LOCAL" />
+      <updated>1748752902990</updated>
+    </task>
+    <option name="localTasksCounter" value="5" />
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="Vcs.Log.Tabs.Properties">
+    <option name="TAB_STATES">
+      <map>
+        <entry key="MAIN">
+          <value>
+            <State />
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+  <component name="VcsManagerConfiguration">
+    <MESSAGE value="remove sms and shouldBlockSend changed" />
+    <MESSAGE value="Fixed logic in OutboundMessagePanel to allow sending WhatsApp messages if either a content template or a message body is provided.&#10;&#10;Updated shouldBlockSend condition to support this new behavior." />
+    <option name="LAST_COMMIT_MESSAGE" value="Fixed logic in OutboundMessagePanel to allow sending WhatsApp messages if either a content template or a message body is provided.&#10;&#10;Updated shouldBlockSend condition to support this new behavior." />
+  </component>
+</project>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "outbound-cbm",
-  "version": "0.0.2",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "outbound-cbm",
-      "version": "0.0.2",
+      "version": "0.0.5",
       "hasInstallScript": true,
       "dependencies": {
         "@twilio-paste/core": "^17.0.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "twilio flex:plugins:start",
     "build": "twilio flex:plugins:build",
     "deploy": "twilio flex:plugins:deploy",
-    "release": "twilio flex:plugins:release --major --changelog=\"Release from CI/CD\""
+    "release": "twilio flex:plugins:release --major --changelog=\"Release from CI/CD\"",
+    "install-flex-plugin": "echo 'Skipping install-flex-plugin in CI'"
   },
   "dependencies": {
     "@twilio-paste/core": "^17.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "twilio flex:plugins:build",
     "deploy": "twilio flex:plugins:deploy",
     "release": "twilio flex:plugins:release --major --changelog=\"Release from CI/CD\"",
-    "install-flex-plugin": "echo 'Skipping install-flex-plugin in CI'"
+    "install-flex-plugin": "echo 'Skipping install-flex-plugin in CI'",
+    "postinstall": "echo 'No postinstall steps needed for this plugin.'"
   },
   "dependencies": {
     "@twilio-paste/core": "^17.0.1",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.5",
   "private": true,
   "scripts": {
+    "start": "twilio flex:plugins:start",
+    "build": "twilio flex:plugins:build",
+    "deploy": "twilio flex:plugins:deploy",
+    "release": "twilio flex:plugins:release --major --changelog=\"Release from CI/CD\"",
     "postinstall": "flex-plugin pre-script-check"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
     "start": "twilio flex:plugins:start",
     "build": "twilio flex:plugins:build",
     "deploy": "twilio flex:plugins:deploy",
-    "release": "twilio flex:plugins:release --major --changelog=\"Release from CI/CD\"",
-    "postinstall": "flex-plugin pre-script-check"
+    "release": "twilio flex:plugins:release --major --changelog=\"Release from CI/CD\""
   },
   "dependencies": {
     "@twilio-paste/core": "^17.0.1",

--- a/scripts/setup-outbound-env.sh
+++ b/scripts/setup-outbound-env.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+# ----- CONFIG -----
+WORKSPACE_NAME="Flex Task Assignment"
+QUEUE_NAME="Everyone"
+WORKFLOW_NAME="outbound-cbm-workflow"
+STUDIO_FLOW_NAME="inbound-cbm-flow"
+ENV_OUTPUT_FILE="$(dirname "$0")/../.env"
+# ------------------
+
+echo "🔍 Locating Workspace..."
+WORKSPACE_SID=$(twilio api:taskrouter:v1:workspaces:list | grep "$WORKSPACE_NAME" | awk '{print $1}')
+if [ -z "$WORKSPACE_SID" ]; then
+  echo "❌ Workspace '$WORKSPACE_NAME' not found."
+  exit 1
+fi
+echo "✅ Workspace SID: $WORKSPACE_SID"
+
+echo "🔍 Locating exact queue '$QUEUE_NAME'..."
+QUEUE_SID=$(twilio api:taskrouter:v1:workspaces:task-queues:list \
+  --workspace-sid "$WORKSPACE_SID" --limit 100 | awk -v name="$QUEUE_NAME" '$0 ~ name && $2 == name { print $1 }')
+if [ -z "$QUEUE_SID" ]; then
+  echo "❌ Queue '$QUEUE_NAME' not found."
+  exit 1
+fi
+echo "✅ Found existing Queue SID: $QUEUE_SID"
+
+echo "🔍 Looking for Workflow '$WORKFLOW_NAME'..."
+WORKFLOW_SID=$(twilio api:taskrouter:v1:workspaces:workflows:list \
+  --workspace-sid "$WORKSPACE_SID" --limit 50 | awk -v name="$WORKFLOW_NAME" '$2 == name { print $1 }')
+
+if [ -z "$WORKFLOW_SID" ]; then
+  echo "➕ Creating Workflow '$WORKFLOW_NAME'..."
+  WORKFLOW_SID=$(twilio api:taskrouter:v1:workspaces:workflows:create \
+    --workspace-sid "$WORKSPACE_SID" \
+    --friendly-name "$WORKFLOW_NAME" \
+    --configuration "{\"task_routing\":{\"filters\":[{\"filter_friendly_name\":\"Known Agent Routing Filter\",\"expression\":\"KnownAgentRoutingFlag == 'true'\",\"targets\":[{\"queue\":\"$QUEUE_SID\",\"known_worker_sid\":\"task.KnownAgentWorkerSid\"}]}],\"default_filter\":{\"queue\":\"$QUEUE_SID\"}}}" \
+    | grep '^sid' | awk '{print $2}')
+
+  if [ -z "$WORKFLOW_SID" ]; then
+    echo "❌ Failed to create Workflow."
+    exit 1
+  fi
+  echo "✅ Created Workflow SID: $WORKFLOW_SID"
+else
+  echo "✅ Found existing Workflow SID: $WORKFLOW_SID"
+fi
+
+echo "🔍 Creating Studio Flow '$STUDIO_FLOW_NAME'..."
+STUDIO_FLOW_SID=$(twilio api:studio:v2:flows:list --limit 20 | grep -B1 "$STUDIO_FLOW_NAME" | grep '^sid' | awk '{print $2}')
+if [ -z "$STUDIO_FLOW_SID" ]; then
+  echo "➕ Creating Studio Flow '$STUDIO_FLOW_NAME'..."
+
+  cat <<EOF > studio_flow.json
+{
+  "description": "Inbound CBM Flow",
+  "states": [
+    {
+      "name": "Trigger",
+      "type": "trigger",
+      "transitions": [
+        { "event": "incomingMessage" },
+        { "event": "incomingCall" },
+        { "next": "send_to_flex_1", "event": "incomingConversationMessage" },
+        { "event": "incomingRequest" },
+        { "event": "incomingParent" }
+      ],
+      "properties": {
+        "offset": { "x": 0, "y": 0 }
+      }
+    },
+    {
+      "name": "send_to_flex_1",
+      "type": "send-to-flex",
+      "transitions": [
+        { "event": "callComplete" },
+        { "event": "failedToEnqueue" },
+        { "event": "callFailure" }
+      ],
+      "properties": {
+        "offset": { "x": 120, "y": 290 },
+        "workflow": "$WORKFLOW_SID",
+        "channel": "TCb7e41c38a2c2d0136e694b9960659974",
+        "attributes": "{\"KnownAgentRoutingFlag\":\"{{trigger.conversation.ChannelAttributes.KnownAgentRoutingFlag}}\", \"KnownAgentWorkerSid\":\"{{trigger.conversation.ChannelAttributes.KnownAgentWorkerSid}}\"}",
+        "priority": "0",
+        "timeout": "3600"
+      }
+    }
+  ],
+  "initial_state": "Trigger",
+  "flags": {
+    "allow_concurrent_calls": true
+  }
+}
+EOF
+
+  STUDIO_FLOW_SID=$(twilio api:studio:v2:flows:create \
+    --friendly-name "$STUDIO_FLOW_NAME" \
+    --status published \
+   --definition "{\"description\":\"Test\",\"states\":[{\"name\":\"Trigger\",\"type\":\"trigger\",\"transitions\":[{\"event\":\"incomingMessage\",\"next\":\"send_to_flex_1\"}],\"properties\":{\"offset\":{\"x\":0,\"y\":0}}},{\"name\":\"send_to_flex_1\",\"type\":\"send-to-flex\",\"transitions\":[],\"properties\":{\"workflow\":\"$WORKFLOW_SID\",\"channel\":\"TC...\",\"attributes\":\"{\\\"KnownAgentRoutingFlag\\\":\\\"{{trigger.conversation.ChannelAttributes.KnownAgentRoutingFlag}}\\\"}\",\"priority\":\"0\",\"timeout\":\"3600\",\"offset\":{\"x\":100,\"y\":100}}}],\"initial_state\":\"Trigger\",\"flags\":{\"allow_concurrent_calls\":true}}" \
+    2> studio_flow_error.log | grep -Eo '^FW[a-zA-Z0-9]+')
+
+
+  if [ -z "$STUDIO_FLOW_SID" ]; then
+    echo "❌ Failed to create Studio Flow."
+    exit 1
+  fi
+  echo "✅ Created Studio Flow SID: $STUDIO_FLOW_SID"
+else
+  echo "✅ Found existing Studio Flow SID: $STUDIO_FLOW_SID"
+fi
+
+echo ""
+echo "✅ All SIDs generated:"
+echo "--------------------------------------------"
+echo "FLEX_APP_WORKSPACE_SID=$WORKSPACE_SID"
+echo "FLEX_APP_QUEUE_SID=$QUEUE_SID"
+echo "FLEX_APP_WORKFLOW_SID=$WORKFLOW_SID"
+echo "FLEX_APP_INBOUND_STUDIO_FLOW=$STUDIO_FLOW_SID"
+echo "--------------------------------------------"
+
+echo "💾 Writing to $ENV_OUTPUT_FILE..."
+cat <<EOF >> $ENV_OUTPUT_FILE
+FLEX_APP_WORKSPACE_SID=$WORKSPACE_SID
+FLEX_APP_QUEUE_SID=$QUEUE_SID
+FLEX_APP_WORKFLOW_SID=$WORKFLOW_SID
+FLEX_APP_INBOUND_STUDIO_FLOW=$STUDIO_FLOW_SID
+EOF
+
+echo "✅ Done. Environment variables written to $ENV_OUTPUT_FILE"

--- a/src/components/OutboundMessagePanel/OutboundMessagePanel.Container.js
+++ b/src/components/OutboundMessagePanel/OutboundMessagePanel.Container.js
@@ -30,7 +30,7 @@ import { fetchContentTemplates } from "../../utils/fetchContentTemplates";
 
 const isWorkerAvailable = (worker) => {
   const { taskrouter_offline_activity_sid } =
-      Manager.getInstance().serviceConfiguration;
+    Manager.getInstance().serviceConfiguration;
 
   return worker.activity?.sid !== taskrouter_offline_activity_sid;
 };
@@ -39,9 +39,10 @@ const isToNumberValid = (toNumber) => {
   const phoneUtil = PhoneNumberUtil.getInstance();
   try {
     const parsedToNumber = phoneUtil.parse(toNumber);
-    const isPossibleNumber = phoneUtil.isPossibleNumber(parsedToNumber);
-    const isValidNumber = phoneUtil.isValidNumber(parsedToNumber);
-    return isPossibleNumber && isValidNumber;
+    if (phoneUtil.isPossibleNumber(parsedToNumber))
+      if (phoneUtil.isValidNumber(parsedToNumber)) return true;
+
+    return false;
   } catch (error) {
     return false;
   }
@@ -54,10 +55,17 @@ const OutboundMessagePanel = (props) => {
   const [contentTemplateSid, setContentTemplateSid] = useState("");
   const [contentTemplates, setContentTemplates] = useState([]);
   const useContentTemplates = process.env.FLEX_APP_USE_CONTENT_TEMPLATES
-      ? process.env.FLEX_APP_USE_CONTENT_TEMPLATES.toLowerCase() === "true"
-      : false;
-  const toNumberValid = isToNumberValid(toNumber);
+    ? process.env.FLEX_APP_USE_CONTENT_TEMPLATES.toLowerCase() === "true"
+    : false;
 
+  const isOutboundMessagePanelOpen = useFlexSelector(
+    (state) =>
+      state.flex.view.componentViewStates?.outboundMessagePanel
+        ?.isOutboundMessagePanelOpen
+  );
+  const worker = useFlexSelector((state) => state.flex.worker);
+
+  const toNumberValid = isToNumberValid(toNumber);
   const isWhatsApp = messageType === "whatsapp";
   const isToNumberInvalid = !toNumberValid;
   const isContentTemplateMissing = !contentTemplateSid;
@@ -67,33 +75,24 @@ const OutboundMessagePanel = (props) => {
       ? isToNumberInvalid || (isContentTemplateMissing && isMessageBodyEmpty)
       : isToNumberInvalid || isMessageBodyEmpty;
 
-
-  const isOutboundMessagePanelOpen = useFlexSelector(
-      (state) =>
-          state.flex.view.componentViewStates?.outboundMessagePanel
-              ?.isOutboundMessagePanelOpen
-  );
-  const worker = useFlexSelector((state) => state.flex.worker);
-
-
   let friendlyPhoneNumber = null;
   const formatter = new AsYouTypeFormatter();
   [...toNumber].forEach((c) => (friendlyPhoneNumber = formatter.inputDigit(c)));
 
   const handleSendClicked = (menuItemClicked) => {
     onSendClickHandler(
-        menuItemClicked,
-        toNumber,
-        messageType,
-        messageBody,
-        contentTemplateSid
+      menuItemClicked,
+      toNumber,
+      messageType,
+      messageBody,
+      contentTemplateSid
     );
   };
 
   useEffect(() => {
     if (messageType === "whatsapp") {
       fetchContentTemplates().then((templates) =>
-          setContentTemplates(templates || [])
+        setContentTemplates(templates || [])
       );
     } else {
       // Clear content templates if messageType is not WhatsApp
@@ -109,141 +108,141 @@ const OutboundMessagePanel = (props) => {
   }
 
   return (
-      <Container>
-        <StyledSidePanel
-            displayName="Message"
-            themeOverride={props.theme && props.theme.OutboundDialerPanel}
-            handleCloseClick={handleClose}
-            title="Message"
-        >
-          {isWorkerAvailable(worker) && (
-              <>
-                {/* Message Type Selection */}
-                <MessageTypeContainer theme={props.theme}>
-                  <RadioGroup
-                      name="messageType"
-                      value={messageType}
-                      legend="Message type"
-                      onChange={(newValue) => {
-                        setMessageType(newValue);
-                        setMessageBody("");
-                        setContentTemplateSid("");
-                      }}
+    <Container>
+      <StyledSidePanel
+        displayName="Message"
+        themeOverride={props.theme && props.theme.OutboundDialerPanel}
+        handleCloseClick={handleClose}
+        title="Message"
+      >
+        {isWorkerAvailable(worker) && (
+          <>
+            {/* Message Type Selection */}
+            <MessageTypeContainer theme={props.theme}>
+              <RadioGroup
+                name="messageType"
+                value={messageType}
+                legend="Message type"
+                onChange={(newValue) => {
+                  setMessageType(newValue);
+                  setMessageBody("");
+                  setContentTemplateSid("");
+                }}
+                orientation="horizontal"
+              >
+                <Radio id="sms" value="sms" name="sms">
+                  SMS
+                </Radio>
+                <Radio id="whatsapp" value="whatsapp" name="whatsapp">
+                  WhatsApp
+                </Radio>
+              </RadioGroup>
+              <Text
+                paddingTop={props.theme.tokens.spacings.space20}
+                color={
+                  toNumberValid
+                    ? props.theme.tokens.textColors.colorTextSuccess
+                    : props.theme.tokens.textColors.colorTextErrorLight
+                }
+              >
+                {messageType === "whatsapp"
+                  ? "whatsapp:" + toNumber
+                  : friendlyPhoneNumber}
+              </Text>
+            </MessageTypeContainer>
+
+            {/* Dialer */}
+            <DialerContainer theme={props.theme}>
+              <Dialer
+                key="dialer"
+                onDial={setToNumber}
+                defaultPhoneNumber={toNumber}
+                onPhoneNumberChange={setToNumber}
+                hideActions
+                disabled={false}
+                defaultCountryAlpha2Code={"US"}
+              />
+            </DialerContainer>
+
+            {/* Conditional Rendering Based on Message Type */}
+            <MessageContainer theme={props.theme}>
+              {messageType === "whatsapp" && useContentTemplates ? (
+                <>
+                  {/* Content Templates Dropdown for WhatsApp */}
+                  <Label htmlFor="select_content_template">
+                    Select a Content Template
+                  </Label>
+                  <Select
+                    id="select_content_template"
+                    onChange={(e) => setContentTemplateSid(e.target.value)}
+                    value={contentTemplateSid}
+                  >
+                    <Option value="">Select a template</Option>
+                    {contentTemplates.map((template) => (
+                      <Option value={template.sid} key={template.sid}>
+                        {template.name}
+                      </Option>
+                    ))}
+                  </Select>
+                  <HelpText>
+                    Choose a content template to send via WhatsApp.
+                  </HelpText>
+                </>
+              ) : (
+                <>
+                  {/* Message Input and Message selector*/}
+                  <Label htmlFor="message-body">Message to send</Label>
+                  <TextArea
+                    theme={props.theme}
+                    onChange={(event) => {
+                      setMessageBody(event.target.value);
+                    }}
+                    id="message-body"
+                    name="message-body"
+                    placeholder="Type message"
+                    value={messageBody}
+                  />
+
+                  <Box backgroundColor="colorBackgroundBody" padding="space50">
+                    <Separator
                       orientation="horizontal"
+                      verticalSpacing="space50"
+                    />
+                  </Box>
+
+                  <Label htmlFor="select_template">Select a Message</Label>
+                  <Select
+                    id="select_template"
+                    onChange={(e) => setMessageBody(e.target.value)}
+                    value={messageBody}
                   >
-                    {/*<Radio id="sms" value="sms" name="sms">*/}
-                    {/*  SMS*/}
-                    {/*</Radio>*/}
-                    <Radio id="whatsapp" value="whatsapp" name="whatsapp">
-                      WhatsApp
-                    </Radio>
-                  </RadioGroup>
-                  <Text
-                      paddingTop={props.theme.tokens.spacings.space20}
-                      color={
-                        toNumberValid
-                            ? props.theme.tokens.textColors.colorTextSuccess
-                            : props.theme.tokens.textColors.colorTextErrorLight
-                      }
-                  >
-                    {messageType === "whatsapp"
-                        ? "whatsapp:" + toNumber
-                        : friendlyPhoneNumber}
-                  </Text>
-                </MessageTypeContainer>
+                    {templates.map((template) => (
+                      <Option value={template} key={template}>
+                        {template || "Type message"}
+                      </Option>
+                    ))}
+                  </Select>
+                  <HelpText>Choose a predefined message to send.</HelpText>
+                </>
+              )}
+            </MessageContainer>
 
-                {/* Dialer */}
-                <DialerContainer theme={props.theme}>
-                  <Dialer
-                      key="dialer"
-                      onDial={setToNumber}
-                      defaultPhoneNumber={toNumber}
-                      onPhoneNumberChange={setToNumber}
-                      hideActions
-                      disabled={false}
-                      defaultCountryAlpha2Code={"US"}
-                  />
-                </DialerContainer>
-
-                {/* Conditional Rendering Based on Message Type */}
-                <MessageContainer theme={props.theme}>
-                  {messageType === "whatsapp" && useContentTemplates ? (
-                      <>
-                        {/* Content Templates Dropdown for WhatsApp */}
-                        <Label htmlFor="select_content_template">
-                          Select a Content Template
-                        </Label>
-                        <Select
-                            id="select_content_template"
-                            onChange={(e) => setContentTemplateSid(e.target.value)}
-                            value={contentTemplateSid}
-                        >
-                          <Option value="">Select a template</Option>
-                          {contentTemplates.map((template) => (
-                              <Option value={template.sid} key={template.sid}>
-                                {template.name}
-                              </Option>
-                          ))}
-                        </Select>
-                        <HelpText>
-                          Choose a content template to send via WhatsApp.
-                        </HelpText>
-                      </>
-                  ) : (
-                      <>
-                        {/* Message Input and Message selector*/}
-                        <Label htmlFor="message-body">Message to send</Label>
-                        <TextArea
-                            theme={props.theme}
-                            onChange={(event) => {
-                              setMessageBody(event.target.value);
-                            }}
-                            id="message-body"
-                            name="message-body"
-                            placeholder="Type message"
-                            value={messageBody}
-                        />
-
-                        <Box backgroundColor="colorBackgroundBody" padding="space50">
-                          <Separator
-                              orientation="horizontal"
-                              verticalSpacing="space50"
-                          />
-                        </Box>
-
-                        <Label htmlFor="select_template">Select a Message</Label>
-                        <Select
-                            id="select_template"
-                            onChange={(e) => setMessageBody(e.target.value)}
-                            value={messageBody}
-                        >
-                          {templates.map((template) => (
-                              <Option value={template} key={template}>
-                                {template || "Type message"}
-                              </Option>
-                          ))}
-                        </Select>
-                        <HelpText>Choose a predefined message to send.</HelpText>
-                      </>
-                  )}
-                </MessageContainer>
-
-                <SendMessageContainer theme={props.theme}>
-                  <SendMessageMenu
-                      disableSend={shouldBlockSend}
-                      onClickHandler={handleSendClicked}
-                  />
-                </SendMessageContainer>
-              </>
-          )}
-          {!isWorkerAvailable(worker) && (
-              <OfflineContainer theme={props.theme}>
-                <ErrorIcon />
-                {`To send a message, please change your status from ${worker.activity.name}`}
-              </OfflineContainer>
-          )}
-        </StyledSidePanel>
-      </Container>
+            <SendMessageContainer theme={props.theme}>
+              <SendMessageMenu
+                disableSend={shouldBlockSend}
+                onClickHandler={handleSendClicked}
+              />
+            </SendMessageContainer>
+          </>
+        )}
+        {!isWorkerAvailable(worker) && (
+          <OfflineContainer theme={props.theme}>
+            <ErrorIcon />
+            {`To send a message, please change your status from ${worker.activity.name}`}
+          </OfflineContainer>
+        )}
+      </StyledSidePanel>
+    </Container>
   );
 };
 

--- a/src/components/OutboundMessagePanel/OutboundMessagePanel.Container.js
+++ b/src/components/OutboundMessagePanel/OutboundMessagePanel.Container.js
@@ -30,7 +30,7 @@ import { fetchContentTemplates } from "../../utils/fetchContentTemplates";
 
 const isWorkerAvailable = (worker) => {
   const { taskrouter_offline_activity_sid } =
-    Manager.getInstance().serviceConfiguration;
+      Manager.getInstance().serviceConfiguration;
 
   return worker.activity?.sid !== taskrouter_offline_activity_sid;
 };
@@ -39,10 +39,9 @@ const isToNumberValid = (toNumber) => {
   const phoneUtil = PhoneNumberUtil.getInstance();
   try {
     const parsedToNumber = phoneUtil.parse(toNumber);
-    if (phoneUtil.isPossibleNumber(parsedToNumber))
-      if (phoneUtil.isValidNumber(parsedToNumber)) return true;
-
-    return false;
+    const isPossibleNumber = phoneUtil.isPossibleNumber(parsedToNumber);
+    const isValidNumber = phoneUtil.isValidNumber(parsedToNumber);
+    return isPossibleNumber && isValidNumber;
   } catch (error) {
     return false;
   }
@@ -55,20 +54,27 @@ const OutboundMessagePanel = (props) => {
   const [contentTemplateSid, setContentTemplateSid] = useState("");
   const [contentTemplates, setContentTemplates] = useState([]);
   const useContentTemplates = process.env.FLEX_APP_USE_CONTENT_TEMPLATES
-    ? process.env.FLEX_APP_USE_CONTENT_TEMPLATES.toLowerCase() === "true"
-    : false;
+      ? process.env.FLEX_APP_USE_CONTENT_TEMPLATES.toLowerCase() === "true"
+      : false;
+  const toNumberValid = isToNumberValid(toNumber);
+
+  const isWhatsApp = messageType === "whatsapp";
+  const isToNumberInvalid = !toNumberValid;
+  const isContentTemplateMissing = !contentTemplateSid;
+  const isMessageBodyEmpty = !messageBody.length;
+
+  const shouldBlockSend = isWhatsApp
+      ? isToNumberInvalid || (isContentTemplateMissing && isMessageBodyEmpty)
+      : isToNumberInvalid || isMessageBodyEmpty;
+
 
   const isOutboundMessagePanelOpen = useFlexSelector(
-    (state) =>
-      state.flex.view.componentViewStates?.outboundMessagePanel
-        ?.isOutboundMessagePanelOpen
+      (state) =>
+          state.flex.view.componentViewStates?.outboundMessagePanel
+              ?.isOutboundMessagePanelOpen
   );
   const worker = useFlexSelector((state) => state.flex.worker);
 
-  let disableSend = true;
-  const toNumberValid = isToNumberValid(toNumber);
-
-  if (toNumberValid && messageBody.length) disableSend = false;
 
   let friendlyPhoneNumber = null;
   const formatter = new AsYouTypeFormatter();
@@ -76,18 +82,18 @@ const OutboundMessagePanel = (props) => {
 
   const handleSendClicked = (menuItemClicked) => {
     onSendClickHandler(
-      menuItemClicked,
-      toNumber,
-      messageType,
-      messageBody,
-      contentTemplateSid
+        menuItemClicked,
+        toNumber,
+        messageType,
+        messageBody,
+        contentTemplateSid
     );
   };
 
   useEffect(() => {
     if (messageType === "whatsapp") {
       fetchContentTemplates().then((templates) =>
-        setContentTemplates(templates || [])
+          setContentTemplates(templates || [])
       );
     } else {
       // Clear content templates if messageType is not WhatsApp
@@ -103,145 +109,141 @@ const OutboundMessagePanel = (props) => {
   }
 
   return (
-    <Container>
-      <StyledSidePanel
-        displayName="Message"
-        themeOverride={props.theme && props.theme.OutboundDialerPanel}
-        handleCloseClick={handleClose}
-        title="Message"
-      >
-        {isWorkerAvailable(worker) && (
-          <>
-            {/* Message Type Selection */}
-            <MessageTypeContainer theme={props.theme}>
-              <RadioGroup
-                name="messageType"
-                value={messageType}
-                legend="Message type"
-                onChange={(newValue) => {
-                  setMessageType(newValue);
-                  setMessageBody("");
-                  setContentTemplateSid("");
-                }}
-                orientation="horizontal"
-              >
-                <Radio id="sms" value="sms" name="sms">
-                  SMS
-                </Radio>
-                <Radio id="whatsapp" value="whatsapp" name="whatsapp">
-                  WhatsApp
-                </Radio>
-              </RadioGroup>
-              <Text
-                paddingTop={props.theme.tokens.spacings.space20}
-                color={
-                  toNumberValid
-                    ? props.theme.tokens.textColors.colorTextSuccess
-                    : props.theme.tokens.textColors.colorTextErrorLight
-                }
-              >
-                {messageType === "whatsapp"
-                  ? "whatsapp:" + toNumber
-                  : friendlyPhoneNumber}
-              </Text>
-            </MessageTypeContainer>
-
-            {/* Dialer */}
-            <DialerContainer theme={props.theme}>
-              <Dialer
-                key="dialer"
-                onDial={setToNumber}
-                defaultPhoneNumber={toNumber}
-                onPhoneNumberChange={setToNumber}
-                hideActions
-                disabled={false}
-                defaultCountryAlpha2Code={"US"}
-              />
-            </DialerContainer>
-
-            {/* Conditional Rendering Based on Message Type */}
-            <MessageContainer theme={props.theme}>
-              {messageType === "whatsapp" && useContentTemplates ? (
-                <>
-                  {/* Content Templates Dropdown for WhatsApp */}
-                  <Label htmlFor="select_content_template">
-                    Select a Content Template
-                  </Label>
-                  <Select
-                    id="select_content_template"
-                    onChange={(e) => setContentTemplateSid(e.target.value)}
-                    value={contentTemplateSid}
-                  >
-                    <Option value="">Select a template</Option>
-                    {contentTemplates.map((template) => (
-                      <Option value={template.sid} key={template.sid}>
-                        {template.name}
-                      </Option>
-                    ))}
-                  </Select>
-                  <HelpText>
-                    Choose a content template to send via WhatsApp.
-                  </HelpText>
-                </>
-              ) : (
-                <>
-                  {/* Message Input and Message selector*/}
-                  <Label htmlFor="message-body">Message to send</Label>
-                  <TextArea
-                    theme={props.theme}
-                    onChange={(event) => {
-                      setMessageBody(event.target.value);
-                    }}
-                    id="message-body"
-                    name="message-body"
-                    placeholder="Type message"
-                    value={messageBody}
-                  />
-
-                  <Box backgroundColor="colorBackgroundBody" padding="space50">
-                    <Separator
+      <Container>
+        <StyledSidePanel
+            displayName="Message"
+            themeOverride={props.theme && props.theme.OutboundDialerPanel}
+            handleCloseClick={handleClose}
+            title="Message"
+        >
+          {isWorkerAvailable(worker) && (
+              <>
+                {/* Message Type Selection */}
+                <MessageTypeContainer theme={props.theme}>
+                  <RadioGroup
+                      name="messageType"
+                      value={messageType}
+                      legend="Message type"
+                      onChange={(newValue) => {
+                        setMessageType(newValue);
+                        setMessageBody("");
+                        setContentTemplateSid("");
+                      }}
                       orientation="horizontal"
-                      verticalSpacing="space50"
-                    />
-                  </Box>
-
-                  <Label htmlFor="select_template">Select a Message</Label>
-                  <Select
-                    id="select_template"
-                    onChange={(e) => setMessageBody(e.target.value)}
-                    value={messageBody}
                   >
-                    {templates.map((template) => (
-                      <Option value={template} key={template}>
-                        {template || "Type message"}
-                      </Option>
-                    ))}
-                  </Select>
-                  <HelpText>Choose a predefined message to send.</HelpText>
-                </>
-              )}
-            </MessageContainer>
+                    {/*<Radio id="sms" value="sms" name="sms">*/}
+                    {/*  SMS*/}
+                    {/*</Radio>*/}
+                    <Radio id="whatsapp" value="whatsapp" name="whatsapp">
+                      WhatsApp
+                    </Radio>
+                  </RadioGroup>
+                  <Text
+                      paddingTop={props.theme.tokens.spacings.space20}
+                      color={
+                        toNumberValid
+                            ? props.theme.tokens.textColors.colorTextSuccess
+                            : props.theme.tokens.textColors.colorTextErrorLight
+                      }
+                  >
+                    {messageType === "whatsapp"
+                        ? "whatsapp:" + toNumber
+                        : friendlyPhoneNumber}
+                  </Text>
+                </MessageTypeContainer>
 
-            <SendMessageContainer theme={props.theme}>
-              <SendMessageMenu
-                disableSend={
-                  messageType === "whatsapp"
-                    ? !toNumberValid || !contentTemplateSid
-                    : !toNumberValid || !messageBody.length
-                }
-                onClickHandler={handleSendClicked}
-              />
-            </SendMessageContainer>
-          </>
-        )}
-        {!isWorkerAvailable(worker) && (
-          <OfflineContainer theme={props.theme}>
-            <ErrorIcon />
-            {`To send a message, please change your status from ${worker.activity.name}`}
-          </OfflineContainer>
-        )}
-      </StyledSidePanel>
-    </Container>
+                {/* Dialer */}
+                <DialerContainer theme={props.theme}>
+                  <Dialer
+                      key="dialer"
+                      onDial={setToNumber}
+                      defaultPhoneNumber={toNumber}
+                      onPhoneNumberChange={setToNumber}
+                      hideActions
+                      disabled={false}
+                      defaultCountryAlpha2Code={"US"}
+                  />
+                </DialerContainer>
+
+                {/* Conditional Rendering Based on Message Type */}
+                <MessageContainer theme={props.theme}>
+                  {messageType === "whatsapp" && useContentTemplates ? (
+                      <>
+                        {/* Content Templates Dropdown for WhatsApp */}
+                        <Label htmlFor="select_content_template">
+                          Select a Content Template
+                        </Label>
+                        <Select
+                            id="select_content_template"
+                            onChange={(e) => setContentTemplateSid(e.target.value)}
+                            value={contentTemplateSid}
+                        >
+                          <Option value="">Select a template</Option>
+                          {contentTemplates.map((template) => (
+                              <Option value={template.sid} key={template.sid}>
+                                {template.name}
+                              </Option>
+                          ))}
+                        </Select>
+                        <HelpText>
+                          Choose a content template to send via WhatsApp.
+                        </HelpText>
+                      </>
+                  ) : (
+                      <>
+                        {/* Message Input and Message selector*/}
+                        <Label htmlFor="message-body">Message to send</Label>
+                        <TextArea
+                            theme={props.theme}
+                            onChange={(event) => {
+                              setMessageBody(event.target.value);
+                            }}
+                            id="message-body"
+                            name="message-body"
+                            placeholder="Type message"
+                            value={messageBody}
+                        />
+
+                        <Box backgroundColor="colorBackgroundBody" padding="space50">
+                          <Separator
+                              orientation="horizontal"
+                              verticalSpacing="space50"
+                          />
+                        </Box>
+
+                        <Label htmlFor="select_template">Select a Message</Label>
+                        <Select
+                            id="select_template"
+                            onChange={(e) => setMessageBody(e.target.value)}
+                            value={messageBody}
+                        >
+                          {templates.map((template) => (
+                              <Option value={template} key={template}>
+                                {template || "Type message"}
+                              </Option>
+                          ))}
+                        </Select>
+                        <HelpText>Choose a predefined message to send.</HelpText>
+                      </>
+                  )}
+                </MessageContainer>
+
+                <SendMessageContainer theme={props.theme}>
+                  <SendMessageMenu
+                      disableSend={shouldBlockSend}
+                      onClickHandler={handleSendClicked}
+                  />
+                </SendMessageContainer>
+              </>
+          )}
+          {!isWorkerAvailable(worker) && (
+              <OfflineContainer theme={props.theme}>
+                <ErrorIcon />
+                {`To send a message, please change your status from ${worker.activity.name}`}
+              </OfflineContainer>
+          )}
+        </StyledSidePanel>
+      </Container>
   );
 };
 


### PR DESCRIPTION
What was done:
Fixed logic in OutboundMessagePanel to allow sending WhatsApp messages if either a content template or a message body is provided.

Updated shouldBlockSend condition to support this new behavior.

Bug:
Previously, the panel required both contentTemplateSid and messageBody for WhatsApp, blocking valid sends where only one was filled.